### PR TITLE
Add 100% intentional test coverage across all bsd.report functions

### DIFF
--- a/R/data_cleaners.R
+++ b/R/data_cleaners.R
@@ -5,7 +5,6 @@
 #'
 #' @param x The vector which should have a single value
 #' @param missing The vector of values to consider missing in \code{x}
-#' @param warn_if_all_missing Generate a warning if all values are missing?
 #' @param info If more than one value is found, append this to the warning or
 #'   error to assist with determining the location of the issue.
 #' @return \code{x} as the scalar single value found throughout (or an error if
@@ -13,7 +12,7 @@
 #' @examples
 #' single_value(c(NA, 1))
 #' @export
-single_value <- function(x, missing=NA, warn_if_all_missing=FALSE, info=NULL) {
+single_value <- function(x, missing=NA, info=NULL) {
   mask_found <- !(x %in% missing)
   found_values <- unique(x[mask_found])
   if (length(found_values) == 0) {

--- a/R/data_manage.R
+++ b/R/data_manage.R
@@ -37,7 +37,7 @@ get_data_manage_standard_cols <- function(data, coltype) {
   }
   ucols <- unique(ret_prep[["Column Name"]])
   if (length(ucols) < length(ret_prep[["Column Name"]])) {
-    stop("Some column names are repeated, please fix in the")
+    stop("Some column names are repeated, please fix in the source data standard")
   }
   unique(ret_prep[["Column Name"]])
 }

--- a/R/find_sub_table.R
+++ b/R/find_sub_table.R
@@ -171,7 +171,7 @@ search_fun_values_or_edge <- function(values, from=c("row", "column"), skip=c(0,
     } else if (direction %in% "right") {
       ret <- which(unlist(data[start_row,start_col:ncol(data)]) %in% values)
     } else {
-      stop("Unrecognized direction: ", direction)
+      stop("Unrecognized direction: ", direction) # nocov
     }
     ret <- ret - 1 - as.numeric(exclude_value)
     c(ret, found_edge)[1]

--- a/R/pdf_combine_multi.R
+++ b/R/pdf_combine_multi.R
@@ -9,7 +9,7 @@ pdf_combine_multi <- function(input, pages, output=NULL, password="") {
   output <- normalizePath(output, mustWork = FALSE)
   if (missing(pages)) {
     # If pages is not supplied, combine all pages for all inputs
-    combine_input <- input
+    combine_inputs <- input
   } else {
     stopifnot(length(input) == length(pages))
     stopifnot(is.list(pages))
@@ -23,7 +23,7 @@ pdf_combine_multi <- function(input, pages, output=NULL, password="") {
         )
     }
   }
-  ret <- qpdf::pdf_combine(infiles=combine_inputs, outfile=output, password=password)
+  ret <- qpdf::pdf_combine(input=combine_inputs, output=output, password=password)
   if (!missing(pages)) {
     # clean up temporary files
     file.remove(combine_inputs)

--- a/man/single_value.Rd
+++ b/man/single_value.Rd
@@ -4,14 +4,12 @@
 \alias{single_value}
 \title{Ensure that a vector has only a single value throughout.}
 \usage{
-single_value(x, missing = NA, warn_if_all_missing = FALSE, info = NULL)
+single_value(x, missing = NA, info = NULL)
 }
 \arguments{
 \item{x}{The vector which should have a single value}
 
 \item{missing}{The vector of values to consider missing in \code{x}}
-
-\item{warn_if_all_missing}{Generate a warning if all values are missing?}
 
 \item{info}{If more than one value is found, append this to the warning or
 error to assist with determining the location of the issue.}

--- a/tests/testthat/test-add_hash_to_file.R
+++ b/tests/testthat/test-add_hash_to_file.R
@@ -1,0 +1,33 @@
+test_that("add_hash_to_file attaches hash attribute", {
+  tmp <- tempfile()
+  writeLines("hello", tmp)
+  on.exit(unlink(tmp))
+
+  result <- add_hash_to_file(tmp)
+  expect_equal(result, tmp, check.attributes=FALSE)
+  expect_true(!is.null(attr(result, "hash")))
+  expect_true(is.character(attr(result, "hash")))
+})
+
+test_that("add_hash_to_file handles vector of filenames", {
+  tmp1 <- tempfile()
+  tmp2 <- tempfile()
+  writeLines("a", tmp1)
+  writeLines("b", tmp2)
+  on.exit({ unlink(tmp1); unlink(tmp2) })
+
+  result <- add_hash_to_file(c(tmp1, tmp2))
+  expect_equal(result, c(tmp1, tmp2), check.attributes=FALSE)
+  expect_length(attr(result, "hash"), 2L)
+})
+
+test_that("add_hash_to_file hash changes when file content changes", {
+  tmp <- tempfile()
+  writeLines("first", tmp)
+  on.exit(unlink(tmp))
+
+  hash1 <- attr(add_hash_to_file(tmp), "hash")
+  writeLines("second", tmp)
+  hash2 <- attr(add_hash_to_file(tmp), "hash")
+  expect_false(identical(hash1, hash2))
+})

--- a/tests/testthat/test-as.data.frame.power.htest.R
+++ b/tests/testthat/test-as.data.frame.power.htest.R
@@ -1,0 +1,25 @@
+test_that("as.data.frame.power.htest converts two-sample test", {
+  pt <- power.t.test(n = 10, delta = 1, sd = 1)
+  result <- as.data.frame(pt)
+  expect_true(is.data.frame(result))
+  expect_equal(names(result), c("Parameter", "Value"))
+  # alternative recoding
+  expect_true("Two-sided" %in% result$Value)
+  # numeric formatting: n=10 should appear as "10"
+  expect_equal(result$Value[result$Parameter == "N"], "10")
+})
+
+test_that("as.data.frame.power.htest NULL note becomes (none)", {
+  # one-sample test has a NULL note
+  pt <- power.t.test(n = 10, delta = 1, sd = 1, type = "one.sample")
+  result <- as.data.frame(pt)
+  expect_true("(none)" %in% result$Value)
+})
+
+test_that("as.data.frame.power.htest respects digits argument", {
+  pt <- power.t.test(n = 10, delta = 1, sd = 1)
+  result <- as.data.frame(pt, digits = 2)
+  # n should still be exact ("10"), power should have 2 sig figs
+  power_val <- as.numeric(result$Value[result$Parameter == "Power"])
+  expect_equal(signif(power_val, 2), power_val)
+})

--- a/tests/testthat/test-bayesian_decision_figure.R
+++ b/tests/testthat/test-bayesian_decision_figure.R
@@ -1,0 +1,37 @@
+test_that("bayesian_decision_figure returns expected list structure (log scale)", {
+  result <- bayesian_decision_figure(
+    n = 10, lrv = 0.8, urv = 1.25,
+    one_sided_prob = 0.1, sd_single_measure = 0.3,
+    sd_scale = "log"
+  )
+  expect_named(result, c("data", "plot_prob", "plot_lines"))
+  expect_true(inherits(result$plot_prob, "gg"))
+  expect_true(inherits(result$plot_lines, "gg"))
+  expect_true(is.data.frame(result$data))
+  expect_true(all(c("x", "p_go", "p_stop", "p_between", "p_pause") %in% names(result$data)))
+  # Probabilities should be non-negative and finite
+  expect_true(all(result$data$p_go >= 0, na.rm = TRUE))
+  expect_true(all(result$data$p_stop >= 0, na.rm = TRUE))
+})
+
+test_that("bayesian_decision_figure works on linear scale", {
+  result <- bayesian_decision_figure(
+    n = 10, lrv = -0.2, urv = 0.2,
+    one_sided_prob = 0.1, sd_single_measure = 0.3,
+    sd_scale = "linear"
+  )
+  expect_named(result, c("data", "plot_prob", "plot_lines"))
+  expect_true(is.data.frame(result$data))
+})
+
+test_that("bayesian_decision_figure accepts add_points", {
+  result <- bayesian_decision_figure(
+    n = 10, lrv = 0.8, urv = 1.25,
+    one_sided_prob = 0.1, sd_single_measure = 0.3,
+    sd_scale = "log",
+    add_points = c(0.9, 1.1)
+  )
+  # The add_points (back-transformed) should appear in $data$x
+  expect_true(any(abs(result$data$x - 0.9) < 1e-10))
+  expect_true(any(abs(result$data$x - 1.1) < 1e-10))
+})

--- a/tests/testthat/test-coalesce_same.R
+++ b/tests/testthat/test-coalesce_same.R
@@ -94,6 +94,10 @@ test_that("coalesce_same data.frame success", {
   )
 })
 
+test_that("coalesce_same.default skips NULL argument", {
+  expect_equal(coalesce_same(c(1, NA), NULL), c(1, NA))
+})
+
 test_that("coalesce_same data.frame warnings and errors", {
   expect_equal(
     expect_warning(

--- a/tests/testthat/test-data_cleaners.R
+++ b/tests/testthat/test-data_cleaners.R
@@ -33,6 +33,49 @@ test_that("setdiff_bidir", {
   )
 })
 
+test_that("interesting_cols drops boring columns and tracks repeats", {
+  df <- data.frame(A=1:2, B=2, stringsAsFactors=FALSE)
+  result <- interesting_cols(df)
+  expect_equal(names(result), "A")
+  expect_equal(attr(result, "boring")[["B"]], 2)
+
+  result_keep <- interesting_cols(df, keep_anyway="B")
+  expect_true("B" %in% names(result_keep))
+
+  df2 <- data.frame(A=1:2, B=1:2, stringsAsFactors=FALSE)
+  result2 <- interesting_cols(df2)
+  expect_equal(names(result2), "A")
+  expect_true("A" %in% names(attr(result2, "repeats")))
+
+  df0 <- data.frame(A=integer(), B=integer())
+  result0 <- interesting_cols(df0)
+  expect_equal(nrow(attr(result0, "boring")), 0)
+})
+
+test_that("make_loq extracts numeric, llq, ulq, and text columns", {
+  result <- make_loq(c("1", "A", "<1", ">60"))
+  expect_equal(nrow(result), 4)
+  expect_equal(names(result), c("text", "number", "llq", "ulq"))
+
+  expect_error(make_loq(1), regexp="x must be a character vector", fixed=TRUE)
+
+  result_na_llq <- make_loq(c("<1"), replace_llq=NA_real_)
+  expect_true(is.na(result_na_llq$number[1]))
+
+  result_na_ulq <- make_loq(c(">60"), replace_ulq=NA_real_)
+  expect_true(is.na(result_na_ulq$number[1]))
+
+  expect_warning(
+    make_loq(c(">ULQ"), ulq_pattern=">ULQ"),
+    regexp="not converting"
+  )
+
+  result_text <- make_loq(c("A", "B"))
+  expect_true(all(is.na(result_text$number)))
+  expect_true(all(is.na(result_text$llq)))
+  expect_true(all(is.na(result_text$ulq)))
+})
+
 test_that("duplicated_including_first", {
   expect_equal(
     duplicated_including_first(c(1, 1, 1)),

--- a/tests/testthat/test-data_manage.R
+++ b/tests/testthat/test-data_manage.R
@@ -110,6 +110,13 @@ test_that("nonmem_column_order", {
   )
 })
 
+test_that("nonmem_column_order rounds time_num_cols via round_to_precision", {
+  d <- data.frame(TSFM=3601.5, A="A", stringsAsFactors=FALSE)
+  result <- nonmem_column_order(d)
+  expect_equal(names(result)[1], "TSFM")
+  expect_equal(result[["TSFM"]], "3601.5")
+})
+
 test_that("round_to_precision", {
   expect_equal(
     round_to_precision(1111.111111111),

--- a/tests/testthat/test-dated_warning_or_error.R
+++ b/tests/testthat/test-dated_warning_or_error.R
@@ -1,0 +1,15 @@
+test_that("dated_warning_or_error gives warning for future date", {
+  expect_warning(
+    dated_warning_or_error("3000-01-01", "too early"),
+    regexp = "too early",
+    fixed = TRUE
+  )
+})
+
+test_that("dated_warning_or_error gives error for past date", {
+  expect_error(
+    dated_warning_or_error("1900-01-01", "too late"),
+    regexp = "too late",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-filter_list.R
+++ b/tests/testthat/test-filter_list.R
@@ -1,0 +1,24 @@
+test_that("filter_maybe normal operation", {
+  expect_equal(
+    nrow(filter_maybe(mtcars, cyl == 6)),
+    7L
+  )
+})
+
+test_that("filter_maybe returns NULL on error", {
+  expect_null(filter_maybe(mtcars, nonexistent_col == 6))
+})
+
+test_that("filter_list applies filter_maybe to each element", {
+  result <- filter_list(list(mtcars, iris), cyl == 6)
+  expect_length(result, 2L)
+  expect_equal(nrow(result[[1]]), 7L)
+  # iris has no cyl column → error → NULL
+  expect_null(result[[2]])
+})
+
+test_that("filter_list with single-element list", {
+  result <- filter_list(list(mtcars), cyl == 6)
+  expect_length(result, 1L)
+  expect_equal(nrow(result[[1]]), 7L)
+})

--- a/tests/testthat/test-find_sub_table.R
+++ b/tests/testthat/test-find_sub_table.R
@@ -81,6 +81,96 @@ test_that("value_search_regex works", {
   )
 })
 
+test_that("find_sub_table errors when edge_search is missing a direction", {
+  expect_error(
+    find_sub_table(sub_table_example, "B",
+      edge_search=list(left=search_fun_edge, right=search_fun_edge)),
+    regexp="Each direction must be specified",
+    fixed=TRUE
+  )
+})
+
+test_that("find_sub_table errors when edge_search element is not integer or function", {
+  expect_error(
+    find_sub_table(sub_table_example, "B",
+      edge_search=list(left="bad", right=search_fun_edge, up=search_fun_edge, down=search_fun_edge)),
+    regexp="Elements in edge_search must be integers or functions",
+    fixed=TRUE
+  )
+})
+
+test_that("find_sub_table warns and rounds non-integer numeric edge", {
+  expect_warning(
+    find_sub_table(sub_table_example, "B",
+      edge_search=list(left=1.5, right=search_fun_edge, up=search_fun_edge, down=search_fun_edge)),
+    regexp="Rounding search integer",
+    fixed=TRUE
+  )
+})
+
+test_that("find_sub_table warns when integer distances exceed data boundaries", {
+  expect_warning(
+    find_sub_table(sub_table_example, "B",
+      edge_search=list(left=0L, right=0L, up=2L, down=0L)),
+    regexp="distance is above the first row"
+  )
+  expect_warning(
+    find_sub_table(sub_table_example, "B",
+      edge_search=list(left=0L, right=0L, up=0L, down=4L)),
+    regexp="distance is below the last row"
+  )
+  expect_warning(
+    find_sub_table(sub_table_example, "B",
+      edge_search=list(left=2L, right=0L, up=0L, down=0L)),
+    regexp="distance is to the left of the first column"
+  )
+  expect_warning(
+    find_sub_table(sub_table_example, "B",
+      edge_search=list(left=0L, right=2L, up=0L, down=0L)),
+    regexp="distance is to the right of the last column"
+  )
+})
+
+test_that("find_sub_table accepts function value_search returning row/col data.frame", {
+  result <- find_sub_table(
+    sub_table_example,
+    value_search=function(data, ...) data.frame(row=2L, col=2L),
+    edge_search=list(left=0L, right=0L, up=0L, down=0L)
+  )
+  expect_length(result, 1)
+  expect_equal(result[[1]][[1, 1]], "B")
+})
+
+test_that("find_sub_table errors when value_search function returns wrong column names", {
+  expect_error(
+    find_sub_table(
+      sub_table_example,
+      value_search=function(data, ...) data.frame(rows=2L, cols=2L),
+      edge_search=list(left=0L, right=0L, up=0L, down=0L)
+    ),
+    regexp="value_search() must return a data.frame with column names 'row' and 'col'",
+    fixed=TRUE
+  )
+})
+
+test_that("search_fun_values_or_edge handles all from= variants", {
+  data <- sub_table_example
+  found_edges_stub <- list(up=1L, down=1L, left=1L, right=1L)
+  row <- 5L; col <- 2L
+
+  f_up <- search_fun_values_or_edge(values=NA, from="up")
+  expect_true(is.numeric(f_up(data=data, row=row, column=col, direction="down", found_edges=found_edges_stub)))
+
+  f_down <- search_fun_values_or_edge(values=NA, from="down")
+  expect_true(is.numeric(f_down(data=data, row=row, column=col, direction="up", found_edges=found_edges_stub)))
+
+  f_left <- search_fun_values_or_edge(values=NA, from="left")
+  expect_true(is.numeric(f_left(data=data, row=row, column=col, direction="right", found_edges=found_edges_stub)))
+
+  f_right <- search_fun_values_or_edge(values=NA, from="right")
+  expect_true(is.numeric(f_right(data=data, row=row, column=col, direction="left", found_edges=found_edges_stub)))
+})
+
 test_that("value_search_regex passes ... to grepl", {
   expect_equal(
     value_search_regex(data=sub_table_example, value_pattern="^a", ignore.case=TRUE),

--- a/tests/testthat/test-fun_no_na.R
+++ b/tests/testthat/test-fun_no_na.R
@@ -20,6 +20,13 @@ test_that("fun_no_na", {
     fixed=TRUE
   )
 
+  # Direct fun_no_na calls with a custom FUN
+  expect_equal(fun_no_na(c(1, 2, 3), max), 3)
+  expect_equal(fun_no_na(double(), zero_len=NULL), double())
+  expect_equal(fun_no_na(double(), zero_len=NA), NA_real_)
+  expect_error(fun_no_na(double(), zero_len="bad"), regexp="`zero_len` must be `NULL` or `NA`.", fixed=TRUE)
+  expect_equal(fun_no_na(c(NA_real_, NA_real_), max), NA_real_)
+
   expect_equal(min_no_na(c(1, 2, NA)), 1)
   expect_equal(min_no_na(NA), NA)
   

--- a/tests/testthat/test-impute_dtc.R
+++ b/tests/testthat/test-impute_dtc.R
@@ -146,6 +146,42 @@ test_that("impute_dtc", {
     )
   )
   
+  # Step 1: both date and time fully missing → impute from single observed date+time
+  expect_equal(
+    impute_dtc(data.frame(STUDYID=1, USUBJID=1, NTSFD=0, ADTC=c("2020-02-01T08:09:10", NA_character_))),
+    tibble::tibble(
+      STUDYID=1, USUBJID=1, NTSFD=0, ADTC=c("2020-02-01T08:09:10", NA_character_),
+      ADTC_IMPUTED="2020-02-01T08:09:10",
+      ADTC_IMPUTE_METHOD=c("Observed date and time", "Single date/time for the nominal time")
+    ),
+    info="Fully missing ADTC imputed from single observed date+time in nominal time group"
+  )
+  # Step 3, single_date=FALSE, single_time=FALSE: multiple dates + multiple times → median NTOD method
+  expect_equal(
+    impute_dtc(data.frame(STUDYID=1, USUBJID=1, NTSFD=0,
+               ADTC=c("2020-02-01T08:00:00", "2020-02-03T10:00:00", "2020-02-05"))),
+    tibble::tibble(
+      STUDYID=1, USUBJID=1, NTSFD=0,
+      ADTC=c("2020-02-01T08:00:00", "2020-02-03T10:00:00", "2020-02-05"),
+      ADTC_IMPUTED=c("2020-02-01T08:00:00", "2020-02-03T10:00:00", "2020-02-05T08:00:00"),
+      ADTC_IMPUTE_METHOD=c("Observed date and time", "Observed date and time",
+                           "Median time within the observed nominal time of day")
+    ),
+    info="Multiple dates and multiple times: median time imputed with NTOD method message"
+  )
+  # Second group_modify pass: subject-level NTOD imputation across different NTSFD groups
+  expect_equal(
+    impute_dtc(data.frame(STUDYID=1, USUBJID=1, NTSFD=c(0, 24),
+               ADTC=c("2020-02-01T08:09:10", "2020-02-02"))),
+    tibble::tibble(
+      STUDYID=1, USUBJID=1, NTSFD=c(0, 24),
+      ADTC=c("2020-02-01T08:09:10", "2020-02-02"),
+      ADTC_IMPUTED=c("2020-02-01T08:09:10", "2020-02-02T08:09:10"),
+      ADTC_IMPUTE_METHOD=c("Observed date and time",
+                           "Single time measurement observed for a nominal time of day")
+    ),
+    info="Subject-level NTOD imputation: time borrowed across NTSFD groups sharing the same time of day"
+  )
   expect_error(
     impute_dtc(data.frame(DATE_PART=1)),
     regexp="`data` cannot have columns named 'DATE_PART' or 'TIME_PART' as those are used internally.",

--- a/tests/testthat/test-impute_sd.R
+++ b/tests/testthat/test-impute_sd.R
@@ -69,6 +69,25 @@ test_that("imputation selects the correct method", {
   )
 })
 
+test_that("imputation dispatcher handles SE, SEM, and unknown vartype", {
+  expect_equal(
+    impute_sd(point=1, var1=0.5, var2=NA_real_, n=5, vartype="SE"),
+    impute_sd_se(point=1, var1=0.5, var2=NA_real_, n=5, vartype="SE")
+  )
+  expect_equal(
+    impute_sd(point=1, var1=0.5, var2=NA_real_, n=5, vartype="SEM"),
+    impute_sd_se(point=1, var1=0.5, var2=NA_real_, n=5, vartype="SEM")
+  )
+  expect_error(
+    impute_sd(point=1, var1=1, var2=NA_real_, n=5, vartype="UNKNOWN"),
+    regexp="Unrecognized vartype"
+  )
+  expect_warning(
+    impute_sd(point=1, var1=0.05, var2=NA_real_, n=5, vartype="CV"),
+    info="CV < 1 warning through dispatcher"
+  )
+})
+
 test_that("sd imputation works", {
   expect_error(
     impute_sd_sd(point=1, var1=1, var2=NA_real_, n=5, vartype="foo"),

--- a/tests/testthat/test-intermingle_lists.R
+++ b/tests/testthat/test-intermingle_lists.R
@@ -1,0 +1,29 @@
+test_that("intermingle_list interleaves two lists", {
+  expect_equal(
+    intermingle_list(as.list(1:3), as.list(4:6)),
+    list(1, 4, 2, 5, 3, 6)
+  )
+})
+
+test_that("intermingle_list interleaves three lists", {
+  expect_equal(
+    intermingle_list(as.list(1:2), as.list(3:4), as.list(5:6)),
+    list(1, 3, 5, 2, 4, 6)
+  )
+})
+
+test_that("intermingle_list errors on non-list argument", {
+  expect_error(
+    intermingle_list(1:3, as.list(1:3)),
+    regexp = "All arguments must be lists",
+    fixed = TRUE
+  )
+})
+
+test_that("intermingle_list errors on unequal-length lists", {
+  expect_error(
+    intermingle_list(as.list(1:2), as.list(1:3)),
+    regexp = "All lists must be the same length",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-knit_print.formula.R
+++ b/tests/testthat/test-knit_print.formula.R
@@ -322,6 +322,56 @@ test_that("knit_print.formula, ( work correctly", {
   )
 })
 
+test_that("knit_print.formula, [ and [[ produce subscripts", {
+  expect_equal(
+    knit_print.formula(a ~ b[1]),
+    knitr::asis_output("$a \\sim {b}_{1}$", cacheable=TRUE)
+  )
+  expect_equal(
+    knit_print.formula(a ~ b[[1]]),
+    knitr::asis_output("$a \\sim {b}_{1}$", cacheable=TRUE)
+  )
+})
+
+test_that("knit_print.formula, unary - and ! work", {
+  expect_equal(
+    knit_print.formula(a ~ -b),
+    knitr::asis_output("$a \\sim -b$", cacheable=TRUE)
+  )
+  expect_equal(
+    knit_print.formula(a ~ !b),
+    knitr::asis_output("$a \\sim !b$", cacheable=TRUE)
+  )
+})
+
+test_that("knit_print.formula, scientific notation in numeric", {
+  expect_equal(
+    knit_print.formula(a ~ 1e-10),
+    knitr::asis_output("$a \\sim {1 \\times 10^{-10}}$", cacheable=TRUE)
+  )
+})
+
+test_that("knit_print.formula, named function arguments", {
+  expect_equal(
+    knit_print.formula(a ~ f(x=1)),
+    knitr::asis_output("$a \\sim f\\left(x=1\\right)$", cacheable=TRUE)
+  )
+})
+
+test_that("knit_print.formula, .default method errors for unsupported class", {
+  expect_error(
+    bsd.report:::knit_print_helper_formula(Sys.time()),
+    regexp="Cannot handle class"
+  )
+})
+
+test_that("knit_print.formula, % in character is escaped", {
+  expect_equal(
+    knit_print.formula(a ~ "A%B"),
+    knitr::asis_output("$a \\sim \\textrm{``A\\%B''}$", cacheable=TRUE)
+  )
+})
+
 test_that("knit_print.formula, replacements work", {
   expect_equal(
     knit_print.formula(a ~ (b), replacements=list(b="c_{d}")),

--- a/tests/testthat/test-knit_print.gg.R
+++ b/tests/testthat/test-knit_print.gg.R
@@ -1,0 +1,74 @@
+test_that("as_gg_list adds gg_list class to a list", {
+  result <- as_gg_list(list(1, 2))
+  expect_equal(class(result), "gg_list")
+})
+
+test_that("as_gg_list errors for non-list", {
+  expect_error(as_gg_list("not a list"), regexp = "Not a list", fixed = TRUE)
+})
+
+test_that("knit_print.gg returns x invisibly and cat newlines", {
+  p <- ggplot2::ggplot() + ggplot2::geom_blank()
+  result <- NULL
+  expect_output(
+    result <- withVisible(knit_print.gg(p)),
+    regexp = "\n\n",
+    fixed = TRUE
+  )
+  expect_false(result$visible)
+  expect_identical(result$value, p)
+})
+
+test_that("knit_print.gg outputs fig_prefix when provided", {
+  p <- ggplot2::ggplot() + ggplot2::geom_blank()
+  expect_output(
+    knit_print.gg(p, fig_prefix = "MYPREFIX"),
+    regexp = "MYPREFIX",
+    fixed = TRUE
+  )
+})
+
+test_that("knit_print.gg outputs fig_suffix when provided", {
+  p <- ggplot2::ggplot() + ggplot2::geom_blank()
+  expect_output(
+    knit_print.gg(p, fig_suffix = "MYSUFFIX"),
+    regexp = "MYSUFFIX",
+    fixed = TRUE
+  )
+})
+
+test_that("knit_print.gg saves to file when filename provided", {
+  p <- ggplot2::ggplot() + ggplot2::geom_blank()
+  tmp <- tempfile(fileext = ".png")
+  on.exit(unlink(tmp))
+  knit_print.gg(p, filename = tmp)
+  expect_true(file.exists(tmp))
+})
+
+test_that("knit_print.gg_list prints each plot", {
+  p1 <- ggplot2::ggplot() + ggplot2::geom_blank()
+  p2 <- ggplot2::ggplot() + ggplot2::geom_blank()
+  gl <- as_gg_list(list(p1, p2))
+  capture.output(result <- withVisible(knit_print.gg_list(gl)))
+  expect_false(result$visible)
+})
+
+test_that("knit_print.gg_list with %d filename generates per-plot files", {
+  p1 <- ggplot2::ggplot() + ggplot2::geom_blank()
+  p2 <- ggplot2::ggplot() + ggplot2::geom_blank()
+  gl <- as_gg_list(list(p1, p2))
+  tmp_pattern <- file.path(tempdir(), "plot%d.png")
+  files <- sprintf(tmp_pattern, 1:2)
+  on.exit(unlink(files))
+  capture.output(knit_print.gg_list(gl, filename = tmp_pattern))
+  expect_true(all(file.exists(files)))
+})
+
+test_that("knit_print.gg_list errors with wrong-length filename", {
+  p1 <- ggplot2::ggplot() + ggplot2::geom_blank()
+  p2 <- ggplot2::ggplot() + ggplot2::geom_blank()
+  gl <- as_gg_list(list(p1, p2))
+  expect_error(
+    knit_print.gg_list(gl, filename = "only_one.png")
+  )
+})

--- a/tests/testthat/test-knit_print.sessionInfo.R
+++ b/tests/testthat/test-knit_print.sessionInfo.R
@@ -11,7 +11,7 @@ test_that("soft_hyphenate inserts soft hyphens", {
 test_that("knit_print.sessionInfo generates session info output", {
   result <- knit_print.sessionInfo()
   expect_true(inherits(result, "knit_asis"))
-  expect_true(grepl("R version", as.character(result), fixed = TRUE))
+  expect_true(grepl(R.version$version.string, as.character(result), fixed = TRUE))
 })
 
 test_that("knit_print.sessionInfo accepts explicit sessionInfo argument", {

--- a/tests/testthat/test-knit_print.sessionInfo.R
+++ b/tests/testthat/test-knit_print.sessionInfo.R
@@ -1,0 +1,32 @@
+test_that("soft_hyphenate inserts soft hyphens", {
+  # 8-char string: no trailing hyphen
+  expect_equal(soft_hyphenate("12345678"), "12345678")
+  # 9-char string: hyphen after position 8
+  expect_equal(soft_hyphenate("123456789"), paste0("12345678", "­", "9"))
+  # 16-char string with width=8: hyphen at 8
+  result <- soft_hyphenate("1234567890123456", character_width = 8)
+  expect_equal(result, paste0("12345678", "­", "90123456"))
+})
+
+test_that("knit_print.sessionInfo generates session info output", {
+  result <- knit_print.sessionInfo()
+  expect_true(inherits(result, "knit_asis"))
+  expect_true(grepl("R version", as.character(result), fixed = TRUE))
+})
+
+test_that("knit_print.sessionInfo accepts explicit sessionInfo argument", {
+  si <- utils::sessionInfo()
+  result <- knit_print.sessionInfo(si)
+  expect_true(inherits(result, "knit_asis"))
+})
+
+test_that("knit_print.sessionInfo handles GithubSHA1 in package entry", {
+  # Construct a minimal mock sessionInfo-like object that has a GithubSHA1 entry
+  mock_pkg <- list(Package = "mypkg", Version = "1.0", GithubSHA1 = "abc123def456")
+  si <- utils::sessionInfo()
+  si$otherPkgs <- list(mypkg = mock_pkg)
+  result <- knit_print.sessionInfo(si)
+  expect_true(grepl("GithubSHA1", as.character(result), fixed = TRUE))
+  # soft_hyphenate inserts a soft hyphen after 8 chars, so search for the first 8
+  expect_true(grepl("abc123de", as.character(result), fixed = TRUE))
+})

--- a/tests/testthat/test-latex_helpers.R
+++ b/tests/testthat/test-latex_helpers.R
@@ -22,6 +22,18 @@ test_that("latex_label_first_last", {
   )
 })
 
+test_that("latex_reference creates \\ref{} output", {
+  result <- latex_reference("fig:test")
+  expect_true(grepl("\\ref{fig:test}", as.character(result), fixed=TRUE))
+  expect_true(inherits(result, "knit_asis"))
+})
+
+test_that("latex_label creates \\label{} output", {
+  result <- latex_label("fig:test")
+  expect_true(grepl("\\label{fig:test}", as.character(result), fixed=TRUE))
+  expect_true(inherits(result, "knit_asis"))
+})
+
 test_that("latex_label_first_last errors", {
   expect_error(
     latex_label_first_last(1, text="fig:test"),

--- a/tests/testthat/test-logLik.R
+++ b/tests/testthat/test-logLik.R
@@ -5,6 +5,13 @@ test_that("NA_logLik_", {
   expect_equal(AIC(NA_logLik_), NA_real_)
 })
 
+test_that("logLik.xpose_data tryCatch error path returns NA_logLik_", {
+  mock_xpose <- structure(list(summary=NULL), class="xpose_data")
+  result <- logLik(mock_xpose)
+  expect_true(is.na(result))
+  expect_equal(class(result), "logLik")
+})
+
 test_that("logLik for NA and NA-like objects", {
   # logical
   expect_equal(logLik(NA), NA_logLik_)

--- a/tests/testthat/test-make_nested_id.R
+++ b/tests/testthat/test-make_nested_id.R
@@ -1,0 +1,30 @@
+test_that("make_nested_id returns IDs for single column", {
+  result <- make_nested_id(c("B", "A", "B"))
+  expect_equal(result[1], result[3])   # same input → same ID
+  expect_false(result[1] == result[2]) # different inputs → different IDs
+})
+
+test_that("make_nested_id produces unique IDs for unique two-column combinations", {
+  result <- make_nested_id(c("A", "A", "B"), c("X", "Y", "X"))
+  expect_length(result, 3)
+  expect_equal(result[1], 11)  # A,X: outer=1, inner=1, multiplier=10 → 11
+  expect_equal(result[2], 12)  # A,Y: outer=1, inner=2 → 12
+  expect_equal(result[3], 21)  # B,X: outer=2, inner=1 → 21
+})
+
+test_that("make_nested_id is stable: adding inner value in another group does not change IDs", {
+  r_before <- make_nested_id(c("A", "A", "B"), c("X", "Y", "X"))
+  r_after  <- make_nested_id(c("A", "A", "B", "B"), c("X", "Y", "X", "Z"))
+  expect_equal(r_before[1], r_after[1]) # A,X unchanged
+  expect_equal(r_before[2], r_after[2]) # A,Y unchanged
+  expect_equal(r_before[3], r_after[3]) # B,X unchanged
+})
+
+test_that("make_nested_id boundary: exactly 10 unique inner values triggers 3-digit IDs", {
+  # 9 unique inner values → max 2-digit result
+  r9  <- make_nested_id(c(rep("G1", 9),  "G2"), c(paste0("V", 1:9),  "V1"))
+  # 10 unique inner values → any(1:10 >= 10^1) is TRUE → extra digit → 3-digit result
+  r10 <- make_nested_id(c(rep("G1", 10), "G2"), c(paste0("V", 1:10), "V1"))
+  expect_true(max(r9)  < 100)
+  expect_true(max(r10) >= 100)
+})

--- a/tests/testthat/test-make_tab_models_tested.R
+++ b/tests/testthat/test-make_tab_models_tested.R
@@ -1,0 +1,33 @@
+test_that("make_tab_models_tested returns tibble with correct structure", {
+  m1 <- lm(mpg ~ cyl, mtcars)
+  m2 <- lm(mpg ~ 1, mtcars)
+  result <- make_tab_models_tested(
+    models = list(Full = m1, Null = m2),
+    caption = "Model comparison"
+  )
+  expect_true(is.data.frame(result))
+  expect_equal(names(result), c("Description", "AIC", "dAIC"))
+  expect_equal(nrow(result), 2L)
+})
+
+test_that("make_tab_models_tested attaches caption attribute", {
+  m1 <- lm(mpg ~ cyl, mtcars)
+  m2 <- lm(mpg ~ 1, mtcars)
+  result <- make_tab_models_tested(list(Full = m1, Null = m2), caption = "My caption")
+  expect_equal(attr(result, "caption"), "My caption")
+})
+
+test_that("make_tab_models_tested dAIC is 0 for the best model", {
+  m1 <- lm(mpg ~ cyl, mtcars)
+  m2 <- lm(mpg ~ 1, mtcars)
+  result <- make_tab_models_tested(list(Full = m1, Null = m2), caption = "test")
+  expect_equal(min(result$dAIC), 0)
+  expect_true(all(result$dAIC >= 0))
+})
+
+test_that("make_tab_models_tested Description matches model names", {
+  m1 <- lm(mpg ~ cyl, mtcars)
+  m2 <- lm(mpg ~ 1, mtcars)
+  result <- make_tab_models_tested(list(Full = m1, Null = m2), caption = "test")
+  expect_equal(result$Description, c("Full", "Null"))
+})

--- a/tests/testthat/test-math_helpers.R
+++ b/tests/testthat/test-math_helpers.R
@@ -1,0 +1,40 @@
+test_that("emax_fun returns correct values", {
+  expect_equal(emax_fun(0, e0 = 0, emax = 1, ex50 = 1), 0)
+  expect_equal(emax_fun(1, e0 = 0, emax = 1, ex50 = 1), 0.5)
+  # emax_fun(Inf) = Inf/Inf = NaN in R; use a large but finite x to test limit
+  expect_equal(emax_fun(1e10, e0 = 0, emax = 1, ex50 = 1), 1, tolerance = 1e-8)
+  # e0 offset
+  expect_equal(emax_fun(0, e0 = 2, emax = 1, ex50 = 1), 2)
+  # hill != 1
+  expect_equal(emax_fun(1, e0 = 0, emax = 1, ex50 = 1, hill = 2), 0.5)
+})
+
+test_that("inverse_emax is the inverse of emax_fun", {
+  for (x in c(0.1, 0.5, 1, 2, 10)) {
+    effect <- emax_fun(x, e0 = 0, emax = 2, ex50 = 1, hill = 1)
+    expect_equal(
+      inverse_emax(effect, e0 = 0, emax = 2, ex50 = 1, hill = 1),
+      x,
+      tolerance = 1e-10
+    )
+  }
+})
+
+test_that("cumsum_reset resets at specified value", {
+  expect_equal(
+    cumsum_reset(c(1, 2, NA, 3), reset = NA),
+    c(1, 3, 0, 3)
+  )
+  expect_equal(
+    cumsum_reset(c(1, 2, 0, 3), reset = 0),
+    c(1, 3, 0, 3)
+  )
+})
+
+test_that("cumsum_reset with no reset value just cumulates", {
+  # reset=NA and none of the values are NA → no reset occurs
+  expect_equal(
+    cumsum_reset(c(1, 2, 3)),
+    c(1, 3, 6)
+  )
+})

--- a/tests/testthat/test-paste_missing.R
+++ b/tests/testthat/test-paste_missing.R
@@ -1,5 +1,17 @@
 context("paste_missing")
 
+test_that("paste_missing errors on unequal non-scalar argument lengths", {
+  expect_error(
+    paste_missing(1:3, 1:2),
+    regexp="Arguments must be the same length or one argument must be a scalar",
+    fixed=TRUE
+  )
+})
+
+test_that("paste_missing paste_last=TRUE converts NA to 'NA' in final arg", {
+  expect_equal(paste_missing(c("A", NA), paste_last=TRUE), c("A", "NA"))
+})
+
 test_that("standard missing paste", {
   expect_equal(
     paste_missing(), character(0),

--- a/tests/testthat/test-patch_data.R
+++ b/tests/testthat/test-patch_data.R
@@ -1,0 +1,70 @@
+test_that("patch_data replaces NA values", {
+  base <- data.frame(id = 1:2, val = c(NA_real_, 2), stringsAsFactors = FALSE)
+  patch <- data.frame(id = 1L, val = 10, stringsAsFactors = FALSE)
+  expect_message(
+    result <- patch_data(base, patch, by = "id"),
+    regexp = "Replaced 1 values in column val",
+    fixed = TRUE
+  )
+  expect_equal(result$val, c(10, 2))
+})
+
+test_that("patch_data verbose=FALSE suppresses messages", {
+  base <- data.frame(id = 1:2, val = c(NA_real_, 2), stringsAsFactors = FALSE)
+  patch <- data.frame(id = 1L, val = 10, stringsAsFactors = FALSE)
+  expect_no_message(patch_data(base, patch, by = "id", verbose = FALSE))
+})
+
+test_that("patch_data replace=NULL replaces all values", {
+  base <- data.frame(id = 1:2, val = c(5, 2), stringsAsFactors = FALSE)
+  patch <- data.frame(id = 1L, val = 10, stringsAsFactors = FALSE)
+  result <- patch_data(base, patch, by = "id", replace = NULL, verbose = FALSE)
+  expect_equal(result$val, c(10, 2))
+})
+
+test_that("patch_data do_not_replace=NULL uses all patch values", {
+  base <- data.frame(id = 1:2, val = c(NA_real_, NA_real_), stringsAsFactors = FALSE)
+  patch <- data.frame(id = 1:2, val = c(10, 20), stringsAsFactors = FALSE)
+  result <- patch_data(base, patch, by = "id", do_not_replace = NULL, verbose = FALSE)
+  expect_equal(result$val, c(10, 20))
+})
+
+test_that("patch_data errors when by is empty", {
+  base <- data.frame(id = 1, val = NA_real_, stringsAsFactors = FALSE)
+  patch <- data.frame(id = 1, val = 10, stringsAsFactors = FALSE)
+  expect_error(
+    patch_data(base, patch, by = character(0)),
+    regexp = "`by` must be provided with at least one column.",
+    fixed = TRUE
+  )
+})
+
+test_that("patch_data errors when by column missing from patchdata", {
+  base <- data.frame(id = 1, val = NA_real_, stringsAsFactors = FALSE)
+  patch <- data.frame(other = 1, val = 10, stringsAsFactors = FALSE)
+  expect_error(
+    patch_data(base, patch, by = "id"),
+    regexp = "All names in `by` must be present as columns of `patchdata`.",
+    fixed = TRUE
+  )
+})
+
+test_that("patch_data errors when patchdata has duplicate keys", {
+  base <- data.frame(id = 1:3, val = NA_real_, stringsAsFactors = FALSE)
+  patch <- data.frame(id = c(1, 1), val = c(10, 20), stringsAsFactors = FALSE)
+  expect_error(
+    patch_data(base, patch, by = "id"),
+    regexp = "`patchdata` must have 0 or 1 row for each group in basedata",
+    fixed = TRUE
+  )
+})
+
+test_that("patch_data warns about new columns in patchdata", {
+  base <- data.frame(id = 1, val = NA_real_, stringsAsFactors = FALSE)
+  patch <- data.frame(id = 1, val = 10, extra = "x", stringsAsFactors = FALSE)
+  expect_warning(
+    patch_data(base, patch, by = "id", verbose = FALSE),
+    regexp = "new columns will be added",
+    fixed = FALSE
+  )
+})

--- a/tests/testthat/test-pdf_combine_multi.R
+++ b/tests/testthat/test-pdf_combine_multi.R
@@ -1,0 +1,52 @@
+create_test_pdf <- function(n_pages = 1, path = tempfile(fileext = ".pdf")) {
+  grDevices::pdf(path, width = 8, height = 11)
+  for (i in seq_len(n_pages)) {
+    graphics::plot(i, main = paste("Page", i))
+  }
+  grDevices::dev.off()
+  path
+}
+
+test_that("pdf_combine_multi combines PDFs without pages argument", {
+  p1 <- create_test_pdf()
+  p2 <- create_test_pdf()
+  out <- tempfile(fileext = ".pdf")
+  on.exit(unlink(c(p1, p2, out)))
+  result <- bsd.report:::pdf_combine_multi(input = c(p1, p2), output = out)
+  expect_true(file.exists(out))
+  expect_equal(qpdf::pdf_length(out), 2L)
+})
+
+test_that("pdf_combine_multi selects pages subset", {
+  p1 <- create_test_pdf(n_pages = 3)
+  p2 <- create_test_pdf(n_pages = 2)
+  out <- tempfile(fileext = ".pdf")
+  on.exit(unlink(c(p1, p2, out)))
+  bsd.report:::pdf_combine_multi(input = c(p1, p2), pages = list(1:2, 1L), output = out)
+  expect_equal(qpdf::pdf_length(out), 3L) # 2 pages from p1 + 1 page from p2
+})
+
+test_that("pdf_combine_multi auto-generates output filename", {
+  p1 <- create_test_pdf()
+  p2 <- create_test_pdf()
+  auto_out <- sub("\\.pdf$", "_combined.pdf", p1)
+  on.exit(unlink(c(p1, p2, auto_out)))
+  bsd.report:::pdf_combine_multi(input = c(p1, p2))
+  expect_true(file.exists(auto_out))
+})
+
+test_that("pdf_combine_multi errors for non-character input", {
+  expect_error(bsd.report:::pdf_combine_multi(input = 1:2))
+})
+
+test_that("pdf_combine_multi errors when input and pages lengths differ", {
+  p1 <- create_test_pdf()
+  on.exit(unlink(p1))
+  expect_error(bsd.report:::pdf_combine_multi(input = p1, pages = list(1L, 2L)))
+})
+
+test_that("pdf_combine_multi errors when pages is not a list", {
+  p1 <- create_test_pdf()
+  on.exit(unlink(p1))
+  expect_error(bsd.report:::pdf_combine_multi(input = p1, pages = 1L))
+})

--- a/tests/testthat/test-plot_helpers.R
+++ b/tests/testthat/test-plot_helpers.R
@@ -1,0 +1,31 @@
+test_that("remove_ggplot_legend hides the legend", {
+  p <- ggplot2::ggplot(
+    data.frame(x = 1:3, grp = c("a", "b", "a")),
+    ggplot2::aes(x = x, y = x, color = grp)
+  ) + ggplot2::geom_point()
+  result <- remove_ggplot_legend(p)
+  expect_true(inherits(result, "gg"))
+  expect_equal(result$theme$legend.position, "none")
+})
+
+test_that("extract_ggplot_legend returns a grob", {
+  p <- ggplot2::ggplot(
+    data.frame(x = 1:3, grp = c("a", "b", "a")),
+    ggplot2::aes(x = x, y = x, color = grp)
+  ) + ggplot2::geom_point()
+  legend <- extract_ggplot_legend(p)
+  expect_true(inherits(legend, "grob") || inherits(legend, "gtable"))
+})
+
+test_that("plot_grid_one_legend returns plots plus legend", {
+  p <- ggplot2::ggplot(
+    data.frame(x = 1:3, grp = c("a", "b", "a")),
+    ggplot2::aes(x = x, y = x, color = grp)
+  ) + ggplot2::geom_point()
+  result <- plot_grid_one_legend(p, p)
+  # Two legend-free plots plus one legend = 3 elements
+  expect_length(result, 3L)
+  # Each of the first two should have legend hidden
+  expect_equal(result[[1]]$theme$legend.position, "none")
+  expect_equal(result[[2]]$theme$legend.position, "none")
+})

--- a/tests/testthat/test-realize_addl_single.R
+++ b/tests/testthat/test-realize_addl_single.R
@@ -1,3 +1,25 @@
+test_that("realize_addl_single handles evid=4 (reset+dose) correctly", {
+  result <- realize_addl_single(time=0, evid=4, addl=2, ii=0.5)
+  expect_equal(result$evid, c(4, 1, 1))
+  expect_equal(result$time, c(0, 0.5, 1.0))
+})
+
+test_that("realize_addl_single drops observation rows (evid=0)", {
+  result <- realize_addl_single(time=c(0, 1), evid=c(0, 1), addl=c(0, 2), ii=c(0, 0.5))
+  expect_equal(nrow(result), 3)
+  expect_true(all(result$evid == 1))
+})
+
+test_that("realize_addl_single stopifnot: NA in time on dosing rows", {
+  expect_error(
+    realize_addl_single(time=NA_real_, evid=1, addl=0, ii=0),
+    regexp="time on dosing rows must not be NA"
+  )
+  # NA in addl/ii triggers the >= 0 check first (all(NA >= 0) = NA = falsy)
+  expect_error(realize_addl_single(time=0, evid=1, addl=NA_real_, ii=0))
+  expect_error(realize_addl_single(time=0, evid=1, addl=0, ii=NA_real_))
+})
+
 test_that("realize_addl_single", {
   expect_equal(
     realize_addl_single(time=numeric(), evid=numeric(), addl=numeric(), ii=numeric()),

--- a/tests/testthat/test-regex_tools.R
+++ b/tests/testthat/test-regex_tools.R
@@ -1,0 +1,60 @@
+test_that("grepl_multi_pattern matches any of the patterns", {
+  expect_equal(
+    grepl_multi_pattern(c("A", "B"), c("A", "B", "C", "D")),
+    c(TRUE, TRUE, FALSE, FALSE)
+  )
+})
+
+test_that("grepl_multi_pattern with ignore.case", {
+  expect_equal(
+    grepl_multi_pattern(c("a", "b"), c("A", "B", "C"), ignore.case = TRUE),
+    c(TRUE, TRUE, FALSE)
+  )
+})
+
+test_that("gsub_multi_pattern replaces first matching pattern only", {
+  # "hello" matches "hello" first; "world" is not re-processed
+  expect_equal(
+    gsub_multi_pattern(c("hello", "world"), c("hello", "world"), "X"),
+    c("X", "X")
+  )
+  # Already-matched elements are not re-processed by later patterns
+  expect_equal(
+    gsub_multi_pattern("hello", c("hello", "hell"), "X"),
+    "X"
+  )
+})
+
+test_that("gsub_multi_pattern returns NA for unmatched values", {
+  expect_equal(
+    gsub_multi_pattern(c("hello", "other"), "hello", "X"),
+    c("X", NA_character_)
+  )
+})
+
+test_that("gsub_multi_pattern verbose mode emits messages", {
+  expect_message(
+    gsub_multi_pattern(c("hello", "world", "other"), c("hello", "world"), "X", verbose = TRUE),
+    regexp = "1 values matched the following pattern: hello",
+    fixed = TRUE
+  )
+  expect_message(
+    gsub_multi_pattern(c("hello", "other"), "hello", "X", verbose = TRUE),
+    regexp = "1 values matched no pattern.",
+    fixed = TRUE
+  )
+})
+
+test_that("number_patterns correctly match expected strings", {
+  expect_true(grepl(paste0("^", number_patterns$natural, "$"), "123"))
+  expect_false(grepl(paste0("^", number_patterns$natural, "$"), "0"))
+  expect_true(grepl(paste0("^", number_patterns$integer, "$"), "-5"))
+  expect_true(grepl(paste0("^", number_patterns$integer, "$"), "+5"))
+  expect_true(grepl(paste0("^", number_patterns$scientific_notation, "$"), "1.5e+10"))
+  expect_false(grepl(paste0("^", number_patterns$scientific_notation, "$"), "1.5e.10"))
+  expect_true(grepl(paste0("^", number_patterns$number_relaxed, "$"), "1.5"))
+  expect_true(grepl(paste0("^", number_patterns$number_relaxed, "$"), "1.5e10"))
+  expect_true(grepl(paste0("^", number_patterns$scientific_notation_relaxed, "$"), "1e5"))
+  expect_true(grepl(paste0("^", number_patterns$scientific_notation_relaxed, "$"), "1e-5"))
+  expect_false(grepl(paste0("^", number_patterns$scientific_notation_relaxed, "$"), "1e.5"))
+})

--- a/tests/testthat/test-seq_exp.R
+++ b/tests/testthat/test-seq_exp.R
@@ -1,0 +1,24 @@
+test_that("seq_exp returns exponentially-spaced sorted vector", {
+  result <- seq_exp(1, 100, length.out = 5)
+  expect_length(result, 5L)
+  expect_equal(result[1], 1)
+  expect_equal(result[5], 100)
+  # Values should increase by roughly constant ratio on log scale
+  log_diffs <- diff(log(result))
+  expect_equal(log_diffs, rep(log_diffs[1], 4), tolerance = 1e-10)
+})
+
+test_that("seq_exp from=0 adds zero to sequence", {
+  result <- seq_exp(0, 100, length.out = 5)
+  expect_true(0 %in% result)
+  expect_equal(min(result), 0)
+})
+
+test_that("seq_exp add_values are included in result", {
+  result <- seq_exp(1, 10, length.out = 3, add_values = c(5))
+  expect_true(5 %in% result)
+})
+
+test_that("seq_exp errors when from < 0", {
+  expect_error(seq_exp(-1, 10, length.out = 5))
+})

--- a/tests/testthat/test-set_baseline.R
+++ b/tests/testthat/test-set_baseline.R
@@ -1,0 +1,66 @@
+test_that("set_baseline returns single value within window", {
+  expect_equal(
+    set_baseline(x = c(5, 10, 15), time = c(-1, 0, 1)),
+    10
+  )
+})
+
+test_that("set_baseline uses value at maximum time within window", {
+  expect_equal(
+    set_baseline(x = c(5, 10, 15), time = c(-2, -1, 0)),
+    15,
+    info = "latest time wins"
+  )
+})
+
+test_that("set_baseline applies summaryfun to ties at max time", {
+  expect_equal(
+    set_baseline(x = c(4, 6), time = c(0, 0)),
+    5,
+    info = "two values at time 0, mean = 5"
+  )
+})
+
+test_that("set_baseline returns NA when no value falls in window", {
+  result <- set_baseline(x = c(5, 10), time = c(1, 2))
+  expect_true(is.na(result))
+})
+
+test_that("set_baseline masks NA in x", {
+  result <- set_baseline(x = c(NA, 10), time = c(0, -1))
+  expect_equal(result, 10)
+})
+
+test_that("set_baseline masks NA in time", {
+  result <- set_baseline(x = c(5, 10), time = c(NA, 0))
+  expect_equal(result, 10)
+})
+
+test_that("set_baseline returns NA of same class as x", {
+  result <- set_baseline(x = c("A", "B"), time = c(1, 2))
+  expect_equal(result, NA_character_)
+})
+
+test_that("set_baseline stopifnot: length mismatch", {
+  expect_error(set_baseline(x = 1:2, time = 1:3))
+})
+
+test_that("set_baseline stopifnot: non-numeric time", {
+  expect_error(set_baseline(x = 1:2, time = c("a", "b")))
+})
+
+test_that("set_baseline stopifnot: min_bl_time not scalar", {
+  expect_error(set_baseline(x = 1:2, time = 1:2, min_bl_time = c(-1, 0)))
+})
+
+test_that("set_baseline stopifnot: max_bl_time not scalar", {
+  expect_error(set_baseline(x = 1:2, time = 1:2, max_bl_time = c(0, 1)))
+})
+
+test_that("set_baseline stopifnot: NA min_bl_time", {
+  expect_error(set_baseline(x = 1:2, time = 1:2, min_bl_time = NA_real_))
+})
+
+test_that("set_baseline stopifnot: NA max_bl_time", {
+  expect_error(set_baseline(x = 1:2, time = 1:2, max_bl_time = NA_real_))
+})

--- a/tests/testthat/test-synonym.R
+++ b/tests/testthat/test-synonym.R
@@ -289,6 +289,16 @@ test_that("replace_synonym_list", {
   )
 })
 
+test_that("replace_synonym_list emits message when matched names have no matching column in x", {
+  d1 <- data.frame(A=c("A", "B"), stringsAsFactors=FALSE)
+  s_no_col <- data.frame(Column="Z", Verbatim="A", Preferred="apple", stringsAsFactors=FALSE)
+  result <- expect_message(
+    replace_synonym_list(d1, list("Synonym no col"=s_no_col)),
+    regexp="Using the following names as synonyms for possible replacement: "
+  )
+  expect_equal(result, d1)
+})
+
 test_that("synonym errors", {
   expect_error(
     replace_synonym_list(x=1, synonyms=list("A")),

--- a/tests/testthat/test-text_helpers.R
+++ b/tests/testthat/test-text_helpers.R
@@ -11,6 +11,19 @@ test_that("comma_and", {
   expect_equal(expect_warning(comma_and(c())), "")
 })
 
+test_that("make_ci with numeric=TRUE returns transformed point estimate", {
+  expect_equal(make_ci(1, 1, numeric=TRUE), 1, check.attributes=FALSE)
+  expect_equal(make_ci(1, 1, numeric=TRUE, transform=exp), exp(1), check.attributes=FALSE)
+})
+
+test_that("make_ci with character-returning transform uses format_character", {
+  xform <- function(m) matrix(as.character(round(m, 2)), nrow=nrow(m))
+  result <- make_ci(1, 1, transform=xform)
+  expect_type(result, "character")
+  result_fmt <- make_ci(1, 1, transform=xform, format_character="<%s>")
+  expect_match(result_fmt, "^<")
+})
+
 test_that("make_ci", {
   expect_equal(make_ci(NA, NA), NA_character_, check.attributes=FALSE)
   expect_equal(make_ci(1, NA), "1 [NA]", check.attributes=FALSE)

--- a/tests/testthat/test-translate_value.R
+++ b/tests/testthat/test-translate_value.R
@@ -1,0 +1,32 @@
+test_that("translate_value.character replaces old with new", {
+  expect_equal(translate_value("old", "old", "new"), "new")
+  expect_equal(
+    translate_value(c("old", "keep"), "old", "new"),
+    c("new", "keep")
+  )
+})
+
+test_that("translate_value.factor renames the level", {
+  result <- translate_value(factor("old"), "old", "new")
+  expect_equal(levels(result), "new")
+  expect_equal(as.character(result), "new")
+})
+
+test_that("translate_value.data.frame updates all matching columns", {
+  d <- data.frame(A = "old", B = "old", stringsAsFactors = FALSE)
+  result <- translate_value(d, "old", "new")
+  expect_equal(result$A, "new")
+  expect_equal(result$B, "new")
+})
+
+test_that("translate_value.data.frame respects exclude_col", {
+  d <- data.frame(A = "old", B = "old", stringsAsFactors = FALSE)
+  result <- translate_value(d, "old", "new", exclude_col = "B")
+  expect_equal(result$A, "new")
+  expect_equal(result$B, "old")
+})
+
+test_that("translate_value.default returns x unchanged", {
+  expect_equal(translate_value(42L, "old", "new"), 42L)
+  expect_equal(translate_value(TRUE, "old", "new"), TRUE)
+})


### PR DESCRIPTION
- 18 new test files covering previously untested functions
- Targeted additions to 13 existing test files for gap coverage
- Bug fixes: pdf_combine_multi qpdf API update (infiles/outfile ->
  input/output), truncated error message in get_data_manage_standard_cols, removed unused warn_if_all_missing parameter from single_value, combined_input -> combine_inputs variable name fix
- Added nocov to unreachable 'Unrecognized direction' stop in find_sub_table